### PR TITLE
Add offline LLM backend and core JSON‑RPC server

### DIFF
--- a/offline_llm/__init__.py
+++ b/offline_llm/__init__.py
@@ -1,0 +1,1 @@
+from .backend import LocalLLM

--- a/offline_llm/backend.py
+++ b/offline_llm/backend.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import http.client
+from pathlib import Path
+from urllib.parse import urlparse
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+
+class LocalLLM:
+    """Simple client for an OpenAI compatible local LLM server."""
+
+    def __init__(self, config_path: str | Path | None = None) -> None:
+        if config_path is None:
+            config_path = Path(__file__).with_name("config.example.toml")
+        if isinstance(config_path, str):
+            config_path = Path(config_path)
+        with open(config_path, "rb") as f:
+            cfg = tomllib.load(f)
+        self.model: str = cfg.get("model", "")
+        self.api_base: str = cfg.get("api_base", "http://localhost:11434")
+        self.prompt_file: str | None = cfg.get("prompt_file")
+        if self.prompt_file is not None:
+            self.prompt_file = str(Path(config_path).parent / self.prompt_file)
+
+    def _make_request(self, payload: dict, stream: bool):
+        url = urlparse(self.api_base)
+        path = url.path.rstrip("/") + "/v1/chat/completions"
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        headers = {"Content-Type": "application/json"}
+        body = json.dumps(payload)
+        conn.request("POST", path, body=body, headers=headers)
+        resp = conn.getresponse()
+        if resp.status != 200:
+            err = resp.read()
+            raise RuntimeError(f"LLM error {resp.status}: {err.decode()}")
+        return resp
+
+    def chat(self, messages: list[dict[str, str]], *, stream: bool = False):
+        payload = {"model": self.model, "messages": messages, "stream": stream}
+        resp = self._make_request(payload, stream)
+        if stream:
+            buffer = ""
+            while True:
+                line = resp.readline()
+                if not line:
+                    break
+                if line.startswith(b"data: "):
+                    line = line[len(b"data: ") :]
+                line = line.strip()
+                if not line or line == b"[DONE]":
+                    continue
+                data = json.loads(line.decode())
+                delta = data["choices"][0].get("delta", {}).get("content")
+                if delta:
+                    yield delta
+        else:
+            data = json.loads(resp.read())
+            return data["choices"][0]["message"]["content"]

--- a/offline_llm/config.example.toml
+++ b/offline_llm/config.example.toml
@@ -1,0 +1,4 @@
+# Example configuration for LocalLLM
+model = "mistral"
+api_base = "http://localhost:11434"
+prompt_file = "offline_llm/default_prompt.txt"

--- a/offline_llm/default_prompt.txt
+++ b/offline_llm/default_prompt.txt
@@ -1,0 +1,10 @@
+Your task is to analyze a crackme in IDA Pro. You can use the MCP tools to retrieve information. In general use the following strategy:
+- Inspect the decompilation and add comments with your findings
+- Rename variables to more sensible names
+- Change the variable and argument types if necessary (especially pointer and array types)
+- Change function names to be more descriptive
+- If more details are necessary, disassemble the function and add comments with your findings
+- NEVER convert number bases yourself. Use the convert_number MCP tool if needed!
+- Do not attempt brute forcing, derive any solutions purely from the disassembly and simple python scripts
+- Create a report.md with your findings and steps taken at the end
+- When you find a solution, prompt the user for feedback with the password you found

--- a/src/ida_pro_mcp/server/__init__.py
+++ b/src/ida_pro_mcp/server/__init__.py
@@ -1,0 +1,1 @@
+from .core import main, JSONRPCServer

--- a/src/ida_pro_mcp/server/core.py
+++ b/src/ida_pro_mcp/server/core.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+from offline_llm.backend import LocalLLM
+
+
+class JSONRPCServer:
+    def __init__(self, llm: LocalLLM, fd: int | None = None) -> None:
+        self.llm = llm
+        if fd is not None:
+            self.infile = os.fdopen(fd, "rb", buffering=0)
+            self.outfile = self.infile  # duplex pipe
+        else:
+            self.infile = sys.stdin.buffer
+            self.outfile = sys.stdout.buffer
+
+    def serve_forever(self) -> None:
+        while True:
+            line = self.infile.readline()
+            if not line:
+                break
+            try:
+                request = json.loads(line)
+            except Exception:
+                continue
+            response = self.handle_request(request)
+            if response is not None:
+                self.outfile.write(json.dumps(response).encode() + b"\n")
+                self.outfile.flush()
+
+    def handle_request(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        method = request.get("method")
+        rpc_id = request.get("id")
+        params = request.get("params", {})
+        if method != "chat":
+            return {
+                "jsonrpc": "2.0",
+                "id": rpc_id,
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+        messages = params.get("messages", [])
+        stream = params.get("stream", False)
+        if stream:
+            for token in self.llm.chat(messages, stream=True):
+                token_resp = {"jsonrpc": "2.0", "id": rpc_id, "token": token}
+                self.outfile.write(json.dumps(token_resp).encode() + b"\n")
+                self.outfile.flush()
+            return {"jsonrpc": "2.0", "id": rpc_id, "done": True}
+        result = self.llm.chat(messages)
+        return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Offline LLM JSON-RPC server")
+    parser.add_argument("--config", type=str, help="Path to config toml")
+    parser.add_argument("--socket-fd", type=int, help="Socket FD from the plugin")
+    args = parser.parse_args(argv)
+
+    llm = LocalLLM(args.config)
+    server = JSONRPCServer(llm, fd=args.socket_fd)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add `offline_llm` package with example config, default prompt and `LocalLLM` backend
- implement `src/ida_pro_mcp/server/core.py` JSON‑RPC server
  - supports `--socket-fd` for plugin‑spawned pipes
  - streams tokens when requested
- expose `JSONRPCServer` and `main` via package init

## Testing
- `python -m py_compile offline_llm/*.py src/ida_pro_mcp/server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684096b978cc833395b24a406edfbd5d