### PR TITLE
Add docs and unit tests

### DIFF
--- a/docs/advanced_usage.adoc
+++ b/docs/advanced_usage.adoc
@@ -1,0 +1,29 @@
+= Advanced Usage
+:toc:
+
+These notes cover more advanced scenarios when working with the MCP server.
+
+== Headless operation
+
+If you have `idalib` installed you can run the server on an IDB in headless
+mode:
+
+[source,shell]
+----
+uv run idalib-mcp --host 127.0.0.1 --port 8745 path/to/executable
+----
+
+This provides the same JSON‑RPC tools without launching the full IDA GUI.
+
+== Development workflow
+
+New tools can be added simply by decorating a function in `mcp-plugin.py` with
+`@jsonrpc`.  Start the development server to experiment with the API:
+
+[source,shell]
+----
+uv run mcp dev src/ida_pro_mcp/server.py
+----
+
+A small web interface opens on http://localhost:5173 allowing you to try out the
+available methods.

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,0 +1,33 @@
+= Configuration
+:toc:
+
+This document covers how to configure different clients and install the plugin
+manually.
+
+== Automatic configuration
+
+Running `ida-pro-mcp --config` prints a JSON snippet that can be pasted into
+supported clients such as Cline, Roo Code or Cursor.  It points the client to
+the local MCP server started with the `--install` command.
+
+== Manual installation
+
+The plugin can also be set up manually.  Clone this repository and configure
+your client with a command similar to:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "github.com/mrexodia/ida-pro-mcp": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/ida-pro-mcp", "run", "server.py", "--install-plugin"],
+      "timeout": 1800,
+      "disabled": false
+    }
+  }
+}
+----
+
+After the server starts the plugin is copied to the IDA plugins directory and
+can be launched from the *Edit → Plugins* menu.

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -1,0 +1,30 @@
+= Quickstart
+:toc:
+
+This guide shows how to get the IDA Pro MCP server running quickly.
+
+== Installation
+
+Install the package directly from GitHub:
+
+[source,shell]
+----
+pip uninstall ida-pro-mcp
+pip install git+https://github.com/mrexodia/ida-pro-mcp
+----
+
+Then install the IDA plugin and configure the local server:
+
+[source,shell]
+----
+ida-pro-mcp --install
+----
+
+Restart IDA Pro and your MCP client to load the plugin.
+
+== Basic usage
+
+Once installed, open a database in IDA and start the server through
+`Edit -> Plugins -> MCP` or by pressing the keyboard shortcut shown by the
+plugin.  Use your favourite MCP client to call the provided tools such as
+`check_connection` or `decompile_function`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ build-backend = "setuptools.build_meta"
 dev = [
     "mcp[cli]>=1.6.0",
 ]
+test = [
+    "pytest",
+]
 
 [project.scripts]
 ida-pro-mcp = "ida_pro_mcp.server:main"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,89 @@
+import importlib.util
+from pathlib import Path
+from unittest import mock
+import types
+import sys
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC))
+
+for name in [
+    "ida_hexrays",
+    "ida_kernwin",
+    "ida_funcs",
+    "ida_gdl",
+    "ida_lines",
+    "ida_idaapi",
+    "idc",
+    "idaapi",
+    "idautils",
+    "ida_nalt",
+    "ida_bytes",
+    "ida_typeinf",
+    "ida_xref",
+    "ida_entry",
+    "ida_idd",
+    "ida_dbg",
+    "ida_name",
+    "ida_ida",
+]:
+    sys.modules.setdefault(name, types.ModuleType(name))
+
+ida_kernwin = sys.modules["ida_kernwin"]
+ida_kernwin.MFF_READ = 0
+ida_kernwin.MFF_WRITE = 1
+ida_kernwin.MFF_FAST = 2
+
+ida_funcs = sys.modules["ida_funcs"]
+class func_t: ...
+ida_funcs.func_t = func_t
+
+ida_hexrays = sys.modules["ida_hexrays"]
+class cfunc_t: ...
+ida_hexrays.cfunc_t = cfunc_t
+ida_hexrays.hexrays_failure_t = type("hexrays_failure_t", (), {})
+ida_hexrays.DECOMP_WARNINGS = 0
+ida_hexrays.OPF_REUSE = 0
+ida_hexrays.ctree_item_t = type("ctree_item_t", (), {})
+ida_hexrays.user_lvar_modifier_t = type("user_lvar_modifier_t", (), {})
+ida_hexrays.lvar_saved_info_t = type("lvar_saved_info_t", (), {})
+ida_hexrays.init_hexrays_plugin = lambda: True
+ida_hexrays.decompile_func = lambda *a, **k: cfunc_t()
+ida_hexrays.get_widget_vdui = lambda w: None
+ida_hexrays.rename_lvar = lambda *a, **k: True
+ida_hexrays.modify_user_lvars = lambda *a, **k: True
+ida_hexrays.open_pseudocode = lambda *a, **k: None
+
+ida_typeinf = sys.modules["ida_typeinf"]
+ida_typeinf.tinfo_t = type("tinfo_t", (), {})
+
+idaapi = sys.modules["idaapi"]
+idaapi.plugin_t = type("plugin_t", (), {})
+idaapi.PLUGIN_KEEP = 0
+idaapi.enable_bpt = lambda *a, **k: True
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "src" / "ida_pro_mcp" / "mcp-plugin.py"
+
+spec = importlib.util.spec_from_file_location("mcp_plugin", PLUGIN_PATH)
+plugin = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plugin)
+
+
+def test_get_metadata():
+    with mock.patch.object(plugin, "get_image_size", return_value=0x2000), \
+         mock.patch.object(plugin, "idaapi") as idaapi, \
+         mock.patch.object(plugin, "ida_nalt") as ida_nalt:
+        idaapi.get_input_file_path.return_value = "/tmp/a.exe"
+        idaapi.get_root_filename.return_value = "a.exe"
+        idaapi.get_imagebase.return_value = 0x401000
+        ida_nalt.retrieve_input_file_md5.return_value = b"\x00" * 16
+        ida_nalt.retrieve_input_file_sha256.return_value = b"\x00" * 32
+        ida_nalt.retrieve_input_file_crc32.return_value = 0x1234
+        ida_nalt.retrieve_input_file_size.return_value = 1024
+
+        result = plugin.get_metadata.__wrapped__()
+
+    assert result["module"] == "a.exe"
+    assert result["size"] == hex(0x2000)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,50 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import sys
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC))
+
+from ida_pro_mcp import server
+
+
+class StubHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        resp = {"jsonrpc": "2.0", "id": body.get("id")}
+        if body["method"] == "get_metadata":
+            resp["result"] = {"module": "test.exe"}
+        else:
+            resp["result"] = "ok"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(resp).encode())
+
+    def log_message(self, *args):
+        pass
+
+
+def run_server(server):
+    with server:
+        server.serve_forever()
+
+
+def test_check_connection(tmp_path):
+    httpd = HTTPServer(("127.0.0.1", 0), StubHandler)
+    thread = threading.Thread(target=run_server, args=(httpd,), daemon=True)
+    thread.start()
+    server.ida_host = "127.0.0.1"
+    server.ida_port = httpd.server_port
+    try:
+        result = server.check_connection()
+        assert "Successfully connected" in result
+        assert "test.exe" in result
+    finally:
+        httpd.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- document quickstart, config, and advanced usage in AsciiDoc
- add pytest suite with mocked `idaapi`
- include pytest as test dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684096bf976c8333aad988031a50c9f9