### PR TITLE
Add GUI dock and core management

### DIFF
--- a/src/ida_pro_mcp/server/__init__.py
+++ b/src/ida_pro_mcp/server/__init__.py
@@ -1,1 +1,54 @@
-from .core import main, JSONRPCServer
+"""Utilities for launching and interacting with the offline MCP core."""
+
+from __future__ import annotations
+
+import sys
+import json
+import http.client
+
+jsonrpc_request_id = 1
+ida_host = "127.0.0.1"
+ida_port = 13337
+
+
+def make_jsonrpc_request(method: str, *params):
+    global jsonrpc_request_id, ida_host, ida_port
+    conn = http.client.HTTPConnection(ida_host, ida_port)
+    request = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": list(params),
+        "id": jsonrpc_request_id,
+    }
+    jsonrpc_request_id += 1
+    try:
+        conn.request("POST", "/mcp", json.dumps(request), {"Content-Type": "application/json"})
+        response = conn.getresponse()
+        data = json.loads(response.read().decode())
+        if "error" in data:
+            error = data["error"]
+            code = error["code"]
+            message = error["message"]
+            pretty = f"JSON-RPC error {code}: {message}"
+            if "data" in error:
+                pretty += "\n" + error["data"]
+            raise Exception(pretty)
+        result = data["result"]
+        if result is None:
+            result = "success"
+        return result
+    finally:
+        conn.close()
+
+
+def check_connection() -> str:
+    """Check if the IDA plugin is running."""
+    try:
+        metadata = make_jsonrpc_request("get_metadata")
+        return f"Successfully connected to IDA Pro (open file: {metadata['module']})"
+    except Exception:
+        if sys.platform == "darwin":
+            shortcut = "Ctrl+Option+M"
+        else:
+            shortcut = "Ctrl+Alt+M"
+        return f"Failed to connect to IDA Pro! Did you run Edit -> Plugins -> MCP ({shortcut}) to start the server?"

--- a/src/ida_pro_mcp/server/gui_dock.py
+++ b/src/ida_pro_mcp/server/gui_dock.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import (
+    QDockWidget,
+    QWidget,
+    QVBoxLayout,
+    QTextEdit,
+    QLineEdit,
+    QToolBar,
+    QAction,
+    QProgressBar,
+)
+from PyQt5.QtCore import Qt
+
+
+class MCPDock(QDockWidget):
+    """Simple dock widget for interacting with the MCP core."""
+
+    def __init__(self, plugin, parent=None) -> None:
+        super().__init__("MCP", parent)
+        self.plugin = plugin
+
+        self.history = QTextEdit()
+        self.history.setReadOnly(True)
+
+        self.prompt = QLineEdit()
+
+        self.toolbar = QToolBar()
+        self.send_action = QAction("Send", self)
+        self.clear_action = QAction("Clear", self)
+        self.toolbar.addAction(self.send_action)
+        self.toolbar.addAction(self.clear_action)
+
+        self.progress = QProgressBar()
+        self.progress.setVisible(False)
+        self.progress.setMaximum(0)
+
+        self.send_action.triggered.connect(self.on_send)
+        self.clear_action.triggered.connect(self.history.clear)
+        self.prompt.returnPressed.connect(self.on_send)
+
+        central = QWidget()
+        layout = QVBoxLayout(central)
+        layout.addWidget(self.history)
+        layout.addWidget(self.prompt)
+        layout.addWidget(self.toolbar)
+        layout.addWidget(self.progress)
+        self.setWidget(central)
+
+    def on_send(self) -> None:
+        text = self.prompt.text().strip()
+        if not text:
+            return
+        self.history.append(f"> {text}")
+        self.prompt.clear()
+        self.progress.setVisible(True)
+        try:
+            if self.plugin:
+                reply = self.plugin.send_prompt(text)
+                if reply:
+                    self.history.append(reply)
+        finally:
+            self.progress.setVisible(False)


### PR DESCRIPTION
## Summary
- add new `MCPDock` QDockWidget UI
- ensure the MCP plugin spawns/reuses the offline core and opens the dock
- simplify `server` package to expose JSON-RPC helpers without extra deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409ed2a22483339b022f6e3e0551d7