### PR TITLE
Document offline usage for IDA Pro MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,27 @@ Unsafe functions (`--unsafe` flag required):
 
 ## Installation
 
-Install the latest version of the IDA Pro MCP package:
+Clone this repository and run the bootstrap script with the path to your
+downloaded model:
 
 ```sh
-pip uninstall ida-pro-mcp
-pip install git+https://github.com/mrexodia/ida-pro-mcp
+git clone https://github.com/mrexodia/ida-pro-mcp
+cd ida-pro-mcp
+scripts/bootstrap.sh /path/to/model.gguf
 ```
 
-Copy `src/ida_pro_mcp/mcp-plugin.py` to your IDA plugins directory (e.g. `%APPDATA%\Hex-Rays\IDA Pro\plugins` on Windows).
-Launch IDA Pro and choose `Edit -> Plugins -> MCP` to start the server.
+The script creates a virtual environment and writes the model location to
+`~/Library/Application Support/ida-offline-mcp/settings.json`.
 
-_Note_: You need to load a binary in IDA before the plugin menu will show up.
+Copy `src/ida_pro_mcp/mcp-plugin.py` to the IDA plugins directory (e.g.
+`%APPDATA%\Hex-Rays\IDA Pro\plugins` on Windows).  Start IDA and choose
+`Edit -> Plugins -> MCP` to launch the chat dock.  Make sure an IDB is loaded
+or the menu entry will not appear.
+
+### Environment variables
+
+Outbound network access from IDAPython is blocked by default.  Set `ALLOW_NET=1`
+before starting IDA if you want to enable connections to external services.
 
 ## Prompt Engineering
 
@@ -99,21 +109,6 @@ Another thing to keep in mind is that LLMs will not perform well on obfuscated c
 
 You should also use a tool like Lumina or FLIRT to try and resolve all the open source library code and the C++ STL, this will further improve the accuracy.
 
-## SSE Transport & Headless MCP
-
-You can run an SSE server to connect to the user interface like this:
-
-```sh
-uv run ida-pro-mcp --transport http://127.0.0.1:8744/sse
-```
-
-After installing [`idalib`](https://docs.hex-rays.com/user-guide/idalib) you can also run a headless SSE server:
-
-```sh
-uv run idalib-mcp --host 127.0.0.1 --port 8745 path/to/executable
-```
-
-_Note_: The `idalib` feature was contributed by [Willi Ballenthin](https://github.com/williballenthin).
 
 ## Manual Installation
 
@@ -134,7 +129,6 @@ There are a few IDA Pro MCP servers floating around, but I created my own for a 
 
 If you want to check them out, here is a list (in the order I discovered them):
 
-- https://github.com/taida957789/ida-mcp-server-plugin (SSE protocol only, requires installing dependencies in IDAPython).
 - https://github.com/fdrechsler/mcp-server-idapro (MCP Server in TypeScript, excessive boilerplate required to add new functionality).
 - https://github.com/MxIris-Reverse-Engineering/ida-mcp-server (custom socket protocol, boilerplate).
 

--- a/docs/advanced_usage.adoc
+++ b/docs/advanced_usage.adoc
@@ -3,17 +3,6 @@
 
 These notes cover more advanced scenarios when working with the MCP server.
 
-== Headless operation
-
-If you have `idalib` installed you can run the server on an IDB in headless
-mode:
-
-[source,shell]
-----
-uv run idalib-mcp --host 127.0.0.1 --port 8745 path/to/executable
-----
-
-This provides the same JSON‑RPC tools without launching the full IDA GUI.
 
 == Development workflow
 

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -1,33 +1,16 @@
 = Configuration
 :toc:
 
-This document covers how to configure different clients and install the plugin
-manually.
+This document explains where to place your model and which environment
+variables affect the plugin.
 
-== Automatic configuration
+== Model location
 
-Running `ida-pro-mcp --config` prints a JSON snippet that can be pasted into
-supported clients such as Cline, Roo Code or Cursor.  It points the client to
-the local MCP server started with the `--install` command.
+`scripts/bootstrap.sh` writes the chosen model path to
+`~/Library/Application Support/ida-offline-mcp/settings.json`.  Edit this
+file to change the model later.
 
-== Manual installation
+== Environment variables
 
-The plugin can also be set up manually.  Clone this repository and configure
-your client with a command similar to:
-
-[source,json]
-----
-{
-  "mcpServers": {
-    "github.com/mrexodia/ida-pro-mcp": {
-      "command": "uv",
-      "args": ["--directory", "/path/to/ida-pro-mcp", "run", "server.py", "--install-plugin"],
-      "timeout": 1800,
-      "disabled": false
-    }
-  }
-}
-----
-
-After the server starts the plugin is copied to the IDA plugins directory and
-can be launched from the *Edit → Plugins* menu.
+`ALLOW_NET=1`:: allow outbound network connections from IDAPython.  The
+plugin blocks non-local traffic by default.

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -5,26 +5,24 @@ This guide shows how to get the IDA Pro MCP server running quickly.
 
 == Installation
 
-Install the package directly from GitHub:
+Clone the repository and run the bootstrap script.  Pass the path to your local
+model as the first argument:
 
 [source,shell]
 ----
-pip uninstall ida-pro-mcp
-pip install git+https://github.com/mrexodia/ida-pro-mcp
+git clone https://github.com/mrexodia/ida-pro-mcp
+cd ida-pro-mcp
+scripts/bootstrap.sh /path/to/model.gguf
 ----
 
-Then install the IDA plugin and configure the local server:
+The script installs all requirements and stores the model path in
+`~/Library/Application Support/ida-offline-mcp/settings.json`.
 
-[source,shell]
-----
-ida-pro-mcp --install
-----
-
-Restart IDA Pro and your MCP client to load the plugin.
+Copy `src/ida_pro_mcp/mcp-plugin.py` to the IDA plugins directory and restart
+IDA to load the plugin.
 
 == Basic usage
 
-Once installed, open a database in IDA and start the server through
-`Edit -> Plugins -> MCP` or by pressing the keyboard shortcut shown by the
-plugin.  Use your favourite MCP client to call the provided tools such as
-`check_connection` or `decompile_function`.
+Once installed, open a database in IDA and launch the MCP plugin through
+`Edit -> Plugins -> MCP`.  A chat dock appears allowing you to interact with the
+MCP tools such as `check_connection` or `decompile_function`.


### PR DESCRIPTION
## Summary
- explain offline installation via `bootstrap.sh`
- show plugin usage and environment variables
- drop SaaS references from advanced docs
- document model location and ALLOW_NET var

## Testing
- `pip install -e .` *(fails: pydantic conflict warning)*
- `PYTHONPATH=. pytest -q` *(fails: module attribute error)*

------
https://chatgpt.com/codex/tasks/task_e_68409ed3fda083338553aeb41f6ddee3