### PR TITLE
Remove stale port reference from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ To test the MCP server itself:
 uv run mcp dev src/ida_pro_mcp/server.py
 ```
 
-This will open a web interface at http://localhost:5173 and allow you to interact with the MCP tools for testing.
-
 For testing I create a symbolic link to the IDA plugin and then POST a JSON-RPC request directly to `http://localhost:13337/mcp`.
 
 Generate the changelog of direct commits to `main`:

--- a/docs/advanced_usage.adoc
+++ b/docs/advanced_usage.adoc
@@ -13,6 +13,3 @@ New tools can be added simply by decorating a function in `mcp-plugin.py` with
 ----
 uv run mcp dev src/ida_pro_mcp/server.py
 ----
-
-A small web interface opens on http://localhost:5173 allowing you to try out the
-available methods.


### PR DESCRIPTION
## Summary
- remove mention of localhost:5173 from advanced usage docs
- drop reference to the development UI port in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2be6cd483339c4443de910d4d19