### PR TITLE
Add offline plugin install helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ downloaded model:
 git clone https://github.com/mrexodia/ida-pro-mcp
 cd ida-pro-mcp
 scripts/bootstrap.sh /path/to/model.gguf
+scripts/install_ida_plugin.sh
 ```
 
 The script creates a virtual environment and writes the model location to
 `~/Library/Application Support/ida-offline-mcp/settings.json`.
 
-Copy `src/ida_pro_mcp/mcp-plugin.py` to the IDA plugins directory (e.g.
-`%APPDATA%\Hex-Rays\IDA Pro\plugins` on Windows).  Start IDA and choose
-`Edit -> Plugins -> MCP` to launch the chat dock.  Make sure an IDB is loaded
-or the menu entry will not appear.
+Run `scripts/install_ida_plugin.sh` to place the plugin in
+`~/.idapro/plugins/`.  Start IDA and choose `Edit -> Plugins -> MCP` to launch
+the chat dock.  Make sure an IDB is loaded or the menu entry will not appear.
 
 ### Environment variables
 
@@ -115,7 +115,7 @@ You should also use a tool like Lumina or FLIRT to try and resolve all the open 
 _Note_: This section is for LLMs and power users who need detailed installation instructions.
 
 ### Manual plugin installation
-1. Copy `src/ida_pro_mcp/mcp-plugin.py` to your IDA plugins folder (`%APPDATA%\Hex-Rays\IDA Pro\plugins` on Windows).
+1. Copy or symlink `src/ida_pro_mcp/mcp-plugin.py` to `~/.idapro/plugins/mcp-plugin.py`.
 2. Open an IDB and click **Edit -> Plugins -> MCP** to start the server.
 
 

--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -18,11 +18,12 @@ scripts/bootstrap.sh /path/to/model.gguf
 The script installs all requirements and stores the model path in
 `~/Library/Application Support/ida-offline-mcp/settings.json`.
 
-Copy `src/ida_pro_mcp/mcp-plugin.py` to the IDA plugins directory and restart
-IDA to load the plugin.
+Run `scripts/install_ida_plugin.sh` to place the plugin under
+`~/.idapro/plugins/` and restart IDA to load it.
 
 == Basic usage
 
 Once installed, open a database in IDA and launch the MCP plugin through
 `Edit -> Plugins -> MCP`.  A chat dock appears allowing you to interact with the
-MCP tools such as `check_connection` or `decompile_function`.
+MCP tools.  Run `check_connection()` in the dock to verify the connection before
+using other tools like `decompile_function`.

--- a/scripts/install_ida_plugin.sh
+++ b/scripts/install_ida_plugin.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+PLUGIN_SRC="$(dirname "$0")/../src/ida_pro_mcp/mcp-plugin.py"
+PLUGIN_DIR="$HOME/.idapro/plugins"
+
+mkdir -p "$PLUGIN_DIR"
+
+if [ "$1" = "--copy" ]; then
+  cp "$PLUGIN_SRC" "$PLUGIN_DIR/mcp-plugin.py"
+else
+  ln -sf "$PLUGIN_SRC" "$PLUGIN_DIR/mcp-plugin.py"
+fi
+
+echo "Plugin installed to $PLUGIN_DIR/mcp-plugin.py"

--- a/src/ida_pro_mcp/jsonrpc_server/core.py
+++ b/src/ida_pro_mcp/jsonrpc_server/core.py
@@ -1,0 +1,36 @@
+import json
+import sys
+from offline_llm.backend import LocalLLM  # offline LLM client
+
+class JSONRPCServer:
+    def __init__(self, llm: LocalLLM):
+        self.llm = llm
+
+    def handle(self, request: dict):
+        method = request.get("method")
+        if method == "chat":
+            params = request.get("params", {})
+            messages = params.get("messages", [])
+            stream = params.get("stream", False)
+            result = self.llm.chat(messages, stream=stream)
+            if stream and not isinstance(result, str):
+                return "".join(result)
+            return result
+        raise Exception(f"Unknown method {method}")
+
+
+def main(argv: list[str] | None = None, llm_class=LocalLLM) -> None:
+    llm = llm_class()
+    server = JSONRPCServer(llm)
+    for line in sys.stdin.buffer:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        try:
+            result = server.handle(request)
+            response = {"jsonrpc": "2.0", "id": request.get("id"), "result": result}
+        except Exception as e:
+            response = {"jsonrpc": "2.0", "id": request.get("id"), "error": {"code": -32000, "message": str(e)}}
+        sys.stdout.buffer.write(json.dumps(response).encode() + b"\n")
+        sys.stdout.buffer.flush()

--- a/src/ida_pro_mcp/server/core.py
+++ b/src/ida_pro_mcp/server/core.py
@@ -1,3 +1,7 @@
-from ..jsonrpc_server.core import JSONRPCServer, LocalLLM, main
+from ..jsonrpc_server.core import JSONRPCServer, main as _main
+from offline_llm.backend import LocalLLM
+
+def main(argv: list[str] | None = None) -> None:
+    _main(argv, llm_class=LocalLLM)
 
 __all__ = ["JSONRPCServer", "LocalLLM", "main"]


### PR DESCRIPTION
## Summary
- add `install_ida_plugin.sh` for installing the IDA plugin
- document the script in the quickstart and README
- rework README to remove old Windows specific paths
- add minimal JSON‑RPC server used in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b65ef44883339d520c3e1d2d0a27