### PR TITLE
Organize plugin structure and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ You should also use a tool like Lumina or FLIRT to try and resolve all the open 
 _Note_: This section is for LLMs and power users who need detailed installation instructions.
 
 ### Manual plugin installation
-1. Copy or symlink `src/ida_pro_mcp/mcp-plugin.py` to `~/.idapro/plugins/mcp-plugin.py`.
+1. Copy or symlink `src/ida_pro_mcp/plugin/__init__.py` to `~/.idapro/plugins/mcp-plugin.py`.
 2. Open an IDB and click **Edit -> Plugins -> MCP** to start the server.
 
 
 
 ## Development
 
-Adding new features is a super easy and streamlined process. All you have to do is add a new `@jsonrpc` function to [`mcp-plugin.py`](https://github.com/mrexodia/ida-pro-mcp/blob/164df8cf4ae251cc9cc0f464591fa6df8e0d9df4/src/ida_pro_mcp/mcp-plugin.py#L406-L419) and your function will be available in the MCP server without any additional boilerplate! Below is a video where I add the `get_metadata` function in less than 2 minutes (including testing):
+Adding new features is a super easy and streamlined process. All you have to do is add a new `@jsonrpc` function to [`plugin/__init__.py`](https://github.com/mrexodia/ida-pro-mcp/blob/164df8cf4ae251cc9cc0f464591fa6df8e0d9df4/src/ida_pro_mcp/plugin/__init__.py#L406-L419) and your function will be available in the MCP server without any additional boilerplate! Below is a video where I add the `get_metadata` function in less than 2 minutes (including testing):
 
 https://github.com/user-attachments/assets/951de823-88ea-4235-adcb-9257e316ae64
 

--- a/docs/advanced_usage.adoc
+++ b/docs/advanced_usage.adoc
@@ -6,7 +6,7 @@ These notes cover more advanced scenarios when working with the MCP server.
 
 == Development workflow
 
-New tools can be added simply by decorating a function in `mcp-plugin.py` with
+New tools can be added simply by decorating a function in `plugin/__init__.py` with
 `@jsonrpc`.  Start the development server to experiment with the API:
 
 [source,shell]

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -2,6 +2,6 @@
   "IDAMetadataDescriptorVersion": 1,
   "plugin": {
     "name": "IDA Pro MCP",
-    "entryPoint": "src/ida_pro_mcp/mcp-plugin.py"
+    "entryPoint": "src/ida_pro_mcp/plugin/__init__.py"
   }
 }

--- a/scripts/install_ida_plugin.sh
+++ b/scripts/install_ida_plugin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-PLUGIN_SRC="$(dirname "$0")/../src/ida_pro_mcp/mcp-plugin.py"
+PLUGIN_SRC="$(dirname "$0")/../src/ida_pro_mcp/plugin/__init__.py"
 PLUGIN_DIR="$HOME/.idapro/plugins"
 
 mkdir -p "$PLUGIN_DIR"

--- a/src/ida_pro_mcp/plugin/__init__.py
+++ b/src/ida_pro_mcp/plugin/__init__.py
@@ -34,6 +34,7 @@ import struct
 import threading
 import http.server
 from urllib.parse import urlparse
+from ida_pro_mcp.util.ida_sync import IDAError, IDASyncError, idaread, idawrite, is_window_active, IDASafety
 from typing import Any, Callable, get_type_hints, TypedDict, Optional, Annotated, TypeVar, Generic
 
 # Core process state
@@ -269,11 +270,6 @@ class Server:
 # A module that helps with writing thread safe ida code.
 # Based on:
 # https://web.archive.org/web/20160305190440/http://www.williballenthin.com/blog/2015/09/04/idapython-synchronization-decorator/
-import logging
-import queue
-import traceback
-import functools
-
 import ida_hexrays
 import ida_kernwin
 import ida_funcs
@@ -293,131 +289,6 @@ import ida_idd
 import ida_dbg
 import ida_name
 import ida_ida
-
-class IDAError(Exception):
-    def __init__(self, message: str):
-        super().__init__(message)
-
-    @property
-    def message(self) -> str:
-        return self.args[0]
-
-class IDASyncError(Exception):
-    pass
-
-# Important note: Always make sure the return value from your function f is a
-# copy of the data you have gotten from IDA, and not the original data.
-#
-# Example:
-# --------
-#
-# Do this:
-#
-#   @idaread
-#   def ts_Functions():
-#       return list(idautils.Functions())
-#
-# Don't do this:
-#
-#   @idaread
-#   def ts_Functions():
-#       return idautils.Functions()
-#
-
-logger = logging.getLogger(__name__)
-
-# Enum for safety modes. Higher means safer:
-class IDASafety:
-    ida_kernwin.MFF_READ
-    SAFE_NONE = ida_kernwin.MFF_FAST
-    SAFE_READ = ida_kernwin.MFF_READ
-    SAFE_WRITE = ida_kernwin.MFF_WRITE
-
-call_stack = queue.LifoQueue()
-
-def sync_wrapper(ff, safety_mode: IDASafety):
-    """
-    Call a function ff with a specific IDA safety_mode.
-    """
-    #logger.debug('sync_wrapper: {}, {}'.format(ff.__name__, safety_mode))
-
-    if safety_mode not in [IDASafety.SAFE_READ, IDASafety.SAFE_WRITE]:
-        error_str = 'Invalid safety mode {} over function {}'\
-                .format(safety_mode, ff.__name__)
-        logger.error(error_str)
-        raise IDASyncError(error_str)
-
-    # No safety level is set up:
-    res_container = queue.Queue()
-
-    def runned():
-        #logger.debug('Inside runned')
-
-        # Make sure that we are not already inside a sync_wrapper:
-        if not call_stack.empty():
-            last_func_name = call_stack.get()
-            error_str = ('Call stack is not empty while calling the '
-                'function {} from {}').format(ff.__name__, last_func_name)
-            #logger.error(error_str)
-            raise IDASyncError(error_str)
-
-        call_stack.put((ff.__name__))
-        try:
-            res_container.put(ff())
-        except Exception as x:
-            res_container.put(x)
-        finally:
-            call_stack.get()
-            #logger.debug('Finished runned')
-
-    ret_val = idaapi.execute_sync(runned, safety_mode)
-    res = res_container.get()
-    if isinstance(res, Exception):
-        raise res
-    return res
-
-def idawrite(f):
-    """
-    decorator for marking a function as modifying the IDB.
-    schedules a request to be made in the main IDA loop to avoid IDB corruption.
-    """
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        ff = functools.partial(f, *args, **kwargs)
-        ff.__name__ = f.__name__
-        return sync_wrapper(ff, idaapi.MFF_WRITE)
-    return wrapper
-
-def idaread(f):
-    """
-    decorator for marking a function as reading from the IDB.
-    schedules a request to be made in the main IDA loop to avoid
-      inconsistent results.
-    MFF_READ constant via: http://www.openrce.org/forums/posts/1827
-    """
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        ff = functools.partial(f, *args, **kwargs)
-        ff.__name__ = f.__name__
-        return sync_wrapper(ff, idaapi.MFF_READ)
-    return wrapper
-
-def is_window_active():
-    """Returns whether IDA is currently active"""
-    try:
-        from PyQt5.QtWidgets import QApplication
-    except ImportError:
-        return False
-
-    app = QApplication.instance()
-    if app is None:
-        return False
-
-    for widget in app.topLevelWidgets():
-        if widget.isActiveWindow():
-            return True
-    return False
-
 class Metadata(TypedDict):
     path: str
     module: str

--- a/src/ida_pro_mcp/util/ida_sync.py
+++ b/src/ida_pro_mcp/util/ida_sync.py
@@ -1,0 +1,132 @@
+import logging
+import queue
+import functools
+
+import ida_kernwin
+import idaapi
+
+
+class IDAError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+    @property
+    def message(self) -> str:
+        return self.args[0]
+
+class IDASyncError(Exception):
+    pass
+
+# Important note: Always make sure the return value from your function f is a
+# copy of the data you have gotten from IDA, and not the original data.
+#
+# Example:
+# --------
+#
+# Do this:
+#
+#   @idaread
+#   def ts_Functions():
+#       return list(idautils.Functions())
+#
+# Don't do this:
+#
+#   @idaread
+#   def ts_Functions():
+#       return idautils.Functions()
+#
+
+logger = logging.getLogger(__name__)
+
+# Enum for safety modes. Higher means safer:
+class IDASafety:
+    ida_kernwin.MFF_READ
+    SAFE_NONE = ida_kernwin.MFF_FAST
+    SAFE_READ = ida_kernwin.MFF_READ
+    SAFE_WRITE = ida_kernwin.MFF_WRITE
+
+call_stack = queue.LifoQueue()
+
+def sync_wrapper(ff, safety_mode: IDASafety):
+    """
+    Call a function ff with a specific IDA safety_mode.
+    """
+    #logger.debug('sync_wrapper: {}, {}'.format(ff.__name__, safety_mode))
+
+    if safety_mode not in [IDASafety.SAFE_READ, IDASafety.SAFE_WRITE]:
+        error_str = 'Invalid safety mode {} over function {}'\
+                .format(safety_mode, ff.__name__)
+        logger.error(error_str)
+        raise IDASyncError(error_str)
+
+    # No safety level is set up:
+    res_container = queue.Queue()
+
+    def runned():
+        #logger.debug('Inside runned')
+
+        # Make sure that we are not already inside a sync_wrapper:
+        if not call_stack.empty():
+            last_func_name = call_stack.get()
+            error_str = ('Call stack is not empty while calling the '
+                'function {} from {}').format(ff.__name__, last_func_name)
+            #logger.error(error_str)
+            raise IDASyncError(error_str)
+
+        call_stack.put((ff.__name__))
+        try:
+            res_container.put(ff())
+        except Exception as x:
+            res_container.put(x)
+        finally:
+            call_stack.get()
+            #logger.debug('Finished runned')
+
+    ret_val = idaapi.execute_sync(runned, safety_mode)
+    res = res_container.get()
+    if isinstance(res, Exception):
+        raise res
+    return res
+
+def idawrite(f):
+    """
+    decorator for marking a function as modifying the IDB.
+    schedules a request to be made in the main IDA loop to avoid IDB corruption.
+    """
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        ff = functools.partial(f, *args, **kwargs)
+        ff.__name__ = f.__name__
+        return sync_wrapper(ff, idaapi.MFF_WRITE)
+    return wrapper
+
+def idaread(f):
+    """
+    decorator for marking a function as reading from the IDB.
+    schedules a request to be made in the main IDA loop to avoid
+      inconsistent results.
+    MFF_READ constant via: http://www.openrce.org/forums/posts/1827
+    """
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        ff = functools.partial(f, *args, **kwargs)
+        ff.__name__ = f.__name__
+        return sync_wrapper(ff, idaapi.MFF_READ)
+    return wrapper
+
+def is_window_active():
+    """Returns whether IDA is currently active"""
+    try:
+        from PyQt5.QtWidgets import QApplication
+    except ImportError:
+        return False
+
+    app = QApplication.instance()
+    if app is None:
+        return False
+
+    for widget in app.topLevelWidgets():
+        if widget.isActiveWindow():
+            return True
+    return False
+

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -70,7 +70,7 @@ idaapi.plugin_t = type("plugin_t", (), {})
 idaapi.PLUGIN_KEEP = 0
 idaapi.enable_bpt = lambda *a, **k: True
 
-PLUGIN_PATH = Path(__file__).resolve().parents[1] / "src" / "ida_pro_mcp" / "mcp-plugin.py"
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "src" / "ida_pro_mcp" / "plugin/__init__.py"
 
 spec = importlib.util.spec_from_file_location("mcp_plugin", PLUGIN_PATH)
 plugin = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- move the MCP plugin into `ida_pro_mcp/plugin` package
- extract IDA synchronization helpers to `ida_pro_mcp/util/ida_sync.py`
- update imports and tests for new locations
- adjust documentation and install script paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bcd196b48333a0ed46b6df4a7dd9